### PR TITLE
링크, 이미지, 비디오 블럭 컴포넌트화 및 스타일 수정

### DIFF
--- a/mocks/development/space.json
+++ b/mocks/development/space.json
@@ -11,7 +11,7 @@
         "w": 2,
         "type": "link",
         "url": "http://www.naver.com",
-        "text": "네이버로 이동!"
+        "text": "네이버"
       },
       {
         "blockId": "block_1_2",
@@ -19,9 +19,9 @@
         "x": 0,
         "h": 1,
         "w": 2,
-        "type": "image",
-        "src": "http://localhost:5173/img1.jpg",
-        "alt": "춤추는 인간"
+        "type": "link",
+        "url": "http://www.youtube.com",
+        "text": "유튜브"
       },
       {
         "blockId": "block_1_3",
@@ -58,8 +58,8 @@
         "x": 0,
         "h": 2,
         "w": 2,
-        "type": "embed",
-        "src": "https://www.youtube.com/embed/75kySTFaBQQ??si=w_qvmC6yYxwunlu0&wmode=opaque",
+        "type": "video",
+        "src": "https://www.youtube.com/embed/75kySTFaBQQ",
         "caption": "yotube playlist 이거 필요없을 거 같인한데, bento처럼 사용자가 캡션을 원할 경우 추가"
       },
       {

--- a/src/components/Blocks/BlockLogo.module.scss
+++ b/src/components/Blocks/BlockLogo.module.scss
@@ -1,6 +1,7 @@
 .container {
     display: flex;
-    width: 3.125rem;
+    max-width: 2.5rem;
+    max-height: 2.5rem;
     overflow: hidden;
     border-radius: .25rem;
 }
@@ -8,6 +9,4 @@
 .logoStyle {
     display: flex;
     width: 100%;
-    height: 100%;
-    // margin: 0;
 }

--- a/src/components/Blocks/ImageBlock.module.scss
+++ b/src/components/Blocks/ImageBlock.module.scss
@@ -1,19 +1,16 @@
 .container {
-  position: relative;
-  display: flex;
   width: 100%;
   height: 100%;
-  justify-content: center;
+  display: flex;
+  overflow: hidden;
+  position: relative;
   align-items: center;
-  // .view {
-  // }
-  // .edit {
-  // }
-  .image {
-    border: 1rem;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 1rem;
-  }
+  border-radius: .625rem;
+  justify-content: center;
+}
+
+img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }

--- a/src/components/Blocks/ImageBlock.tsx
+++ b/src/components/Blocks/ImageBlock.tsx
@@ -9,7 +9,13 @@ export function ImageBlock({ block, mode }: Props) {
   return (
     <div className={styles.container}>
       <div className={mode === 'edit' ? 'cover' : ''} />
-      <img className={styles.image} src={block.src} alt={block.alt} />
+      <img
+        // * 이상하게 이미지는 css module이 적용이 안됨 ㅠㅠ 이유를 모르곘음 ㅠㅠㅠ 흑흑
+        // className={mode}
+        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        src={block.src}
+        alt={block.alt}
+      />
     </div>
   )
 }

--- a/src/components/Blocks/LinkBlock.module.scss
+++ b/src/components/Blocks/LinkBlock.module.scss
@@ -1,26 +1,60 @@
 .container {
-  position: relative;
-  display: flex;
   width: 100%;
   height: 100%;
+  display: flex;
+  overflow: hidden;
+  border-radius: 0.625rem;
+  flex-direction: column;
+  background-color: white;
   justify-content: center;
   align-items: center;
-  .view {
+
+  .itemBox {
     width: 100%;
     height: 100%;
-    z-index: 1;
+    display: flex;
+    padding-top: 1.25rem;
+    padding-left: 1.25rem;
+    .titleUrl {
+      display: flex;
+      flex-direction: column;
+      margin-left: 1.25rem;
+      span {
+        display: flex;
+        font-weight: 700;
+        font-size: 0.875rem;
+      }
+      a {
+        font-size: 0.75rem;
+      }
+    }
   }
-  .edit {
-    width: 80%;
-    height: 80%;
-    z-index: 1;
+  .footer {
+    display: flex;
+    width: 100%;
+    color: white;
+    height: 2.1875rem;
+    background-color: black;
+    justify-content: space-between;
+    .footerLeft {
+      display: flex;
+      padding-left: 1.25rem;
+      align-items: center;
+    }
+    .footerright {
+      display: flex;
+      width: 2.1875rem;
+      background-color: #3b4753;
+    }
   }
-  .cover {
-    position: absolute;
-    z-index: 2;
-    width: 80%;
-    height: 80%;
-    border-radius: 1rem;
-    background-color: rgba(0, 0, 0, 0.5);
-  }
+}
+
+.edit {
+  width: 100%;
+  height: 100%;
+}
+
+.cover {
+  width: 100%;
+  height: 100%;
 }

--- a/src/components/Blocks/LinkBlock.tsx
+++ b/src/components/Blocks/LinkBlock.tsx
@@ -8,13 +8,22 @@ type Props = {
 }
 
 export function LinkBlock({ block, mode }: Props) {
+  // eslint-disable-next-line no-console
+  console.log('a', block)
   return (
     <div className={styles.container}>
-      <BlockLogo logo={block.url} />
       <div className={mode === 'edit' ? 'cover' : ''} />
-      <div className={mode}>
-        <a href={block.url}>{block.text}</a>
+      <div className={styles.itemBox}>
+        <BlockLogo logo={block.url} />
+        <div className={styles.titleUrl}>
+          <span>{block.text}</span>
+          <a href={block.url}>{block.url}</a>
+        </div>
       </div>
+      {/* <div className={styles.footer}>
+        <div className={styles.footerLeft}>바로가기</div>
+        <div className={styles.footerright} />
+      </div> */}
     </div>
   )
 }

--- a/src/components/Blocks/VideoBlock.module.scss
+++ b/src/components/Blocks/VideoBlock.module.scss
@@ -6,8 +6,8 @@
   justify-content: center;
   align-items: center;
   .edit {
-    width: 100%;
-    height: 100%;
+    width: 80%;
+    height: 80%;
     border-radius: 1rem;
   }
   .view {

--- a/src/components/Blocks/VideoBlock.tsx
+++ b/src/components/Blocks/VideoBlock.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable multiline-ternary */
 import { type BlockWith } from '@/models/space'
 import styles from './VideoBlock.module.scss'
 
@@ -9,8 +10,11 @@ export function VideoBlock({ block, mode }: Props) {
   return (
     <div className={styles.container}>
       <div className={mode === 'edit' ? 'cover' : ''} />
-      <video className={mode} src={block.src} controls autoPlay />
-      <div className={styles.loading}>Loading...</div>
+      {block.src.includes('youtube') ? (
+        <iframe className={mode} src={`${block.src}?autoplay=1&mute=1`} />
+      ) : (
+        <video className={mode} src={block.src} controls autoPlay loop />
+      )}
     </div>
   )
 }

--- a/src/components/Forms/ImageBlockForm.module.scss
+++ b/src/components/Forms/ImageBlockForm.module.scss
@@ -1,5 +1,7 @@
 .container {
-  background-color: white;
+  width: 100%;
+  height: auto;
+  display: flex;
 }
 
 .addImgButton {
@@ -13,6 +15,16 @@
   border-radius: .375rem;
   justify-content: center;
   border: solid .0625rem #000000;
+}
+
+.formBox {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  .forms {
+    padding: 0 20px 0 20px;
+  }
 }
 
 .thumbnailImg {

--- a/src/components/Forms/ImageBlockForm.tsx
+++ b/src/components/Forms/ImageBlockForm.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable multiline-ternary */
-/* eslint-disable @typescript-eslint/quotes */
 import { useState, type ChangeEvent, type FormEvent } from 'react'
 import FormButton from '../Ui/Button'
+import Thumbnail from '../Ui/Thumbnail'
 import styles from './ImageBlockForm.module.scss'
 
 export default function ImageBlockForm() {
-  const [key, setKey] = useState(0)
   const [thumbnail, setThumbnail] = useState<string>('')
   const [title, setTitle] = useState<string>('')
   const isButtonDisabled = !title || !thumbnail
@@ -19,24 +17,7 @@ export default function ImageBlockForm() {
     // body에 data를 담아 post 전달 알림창으로 체크
     alert(JSON.stringify(body))
   }
-  // 제품 썸네일 이미지 Base64 포멧 변환
-  function changeImg(e: React.ChangeEvent<HTMLInputElement>) {
-    const files = e.target.files as FileList
-    for (const file of files) {
-      const reader = new FileReader()
-      reader.readAsDataURL(file)
-      reader.addEventListener('load', (e) => {
-        setThumbnail((e.target as FileReader).result as string)
-        setKey((e) => e + 1)
-      })
-    }
-  }
-  /** 썸네일 이미지 삭제 기능 */
-  function changeImgRemove() {
-    setThumbnail('')
-    setKey((e) => e + 1)
-  }
-  // 이미지
+
   const onChangetitle = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault()
     setTitle(e.target.value)
@@ -44,36 +25,13 @@ export default function ImageBlockForm() {
 
   return (
     <div className={styles.container}>
-      <form onSubmit={submitHandler}>
-        <h3>사진 제목*</h3>
-        <input type="text" value={title} onChange={onChangetitle} placeholder="사진 제목을 입력해주세요." />
-        <h3>사진 첨부</h3>
-        <label htmlFor="file" className={styles.addImgButton}>
-          +
-        </label>
-        <input
-          type="file"
-          id="file"
-          name="file"
-          onChange={(e) => {
-            changeImg(e)
-          }}
-          style={{ display: 'none' }}
-          key={key}
-        />
-        {thumbnail ? (
-          <div
-            className={styles.thumbnailImg}
-            onClick={() => {
-              changeImgRemove()
-            }}
-          >
-            <img src={thumbnail} />
-            <div className={styles.minus}>-</div>
-          </div>
-        ) : (
-          <div style={{ display: 'none' }} />
-        )}
+      <form className={styles.formBox} onSubmit={submitHandler}>
+        <div className={styles.forms}>
+          <h3>사진 제목*</h3>
+          <input type="text" value={title} onChange={onChangetitle} placeholder="사진 제목을 입력해주세요." />
+          <h3>사진 첨부</h3>
+          <Thumbnail img={thumbnail} imgData={setThumbnail} />
+        </div>
         <FormButton title={'사진 추가하기'} event={isButtonDisabled} />
       </form>
     </div>

--- a/src/components/Forms/LinkBlockForm.module.scss
+++ b/src/components/Forms/LinkBlockForm.module.scss
@@ -1,4 +1,6 @@
 .container {
+  width: 100%;
+  height: auto;
   display: flex;
 }
 
@@ -15,4 +17,7 @@ input {
   width: 100%;
   flex-direction: column;
   justify-content: space-between;
+  .forms {
+    padding: 0 20px 0 20px;
+  }
 }

--- a/src/components/Forms/LinkBlockForm.tsx
+++ b/src/components/Forms/LinkBlockForm.tsx
@@ -28,7 +28,7 @@ export default function LinkBlockForm() {
   return (
     <div className={styles.container}>
       <form className={styles.formBox} onSubmit={submitHandler}>
-        <div>
+        <div className={styles.forms}>
           <h3>URL 링크 주소 제목</h3>
           <input type="text" value={title} onChange={onChangeTitle} placeholder="링크 제목을 입력해주세요." />
           <h3>URL 링크 주소 삽입</h3>

--- a/src/components/Forms/VideoBlockForm.module.scss
+++ b/src/components/Forms/VideoBlockForm.module.scss
@@ -1,5 +1,7 @@
 .container {
-  background-color: white;
+  width: 100%;
+  height: auto;
+  display: flex;
 }
 
 .addVideoButton {
@@ -42,7 +44,7 @@
 .thumbnailVideo:hover {
   .minus {
     display: flex;
-    color: #ff0606;
+    background-color: white;
   }
 }
 
@@ -50,5 +52,15 @@
   display: flex;
   input {
     margin-right: 4px;
+  }
+}
+
+.formBox {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  .forms {
+    padding: 0 20px 0 20px;
   }
 }

--- a/src/components/Forms/VideoBlockForm.tsx
+++ b/src/components/Forms/VideoBlockForm.tsx
@@ -1,14 +1,12 @@
-/* eslint-disable multiline-ternary */
-/* eslint-disable @typescript-eslint/quotes */
 import { useState, type ChangeEvent, type FormEvent } from 'react'
 import FormButton from '../Ui/Button'
+import Thumbnail from '../Ui/Thumbnail'
 import styles from './VideoBlockForm.module.scss'
 
 export default function VideoBlockForm() {
   const [selectedRadio, setSelectedRadio] = useState('radio1')
   const [thumbnail, setThumbnail] = useState<string>('')
   const [title, setTitle] = useState<string>('')
-  const [key, setKey] = useState(0)
 
   const [isButtonDisabled, setIsButtonDisabled] = useState(true)
 
@@ -21,26 +19,7 @@ export default function VideoBlockForm() {
     // body에 data를 담아 post 전달 알림창으로 체크
     alert(JSON.stringify(body))
   }
-  // 제품 썸네일 이미지 Base64 포멧 변환
-  function changeVideo(e: React.ChangeEvent<HTMLInputElement>) {
-    const files = e.target.files as FileList
-    for (const file of files) {
-      const reader = new FileReader()
-      reader.readAsDataURL(file)
-      reader.addEventListener('load', (e) => {
-        setThumbnail((e.target as FileReader).result as string)
-        setKey((e) => e + 1)
-      })
-    }
-    setIsButtonDisabled(e.target.value === '')
-  }
-  /** 썸네일 이미지 삭제 기능 */
-  function changeVideoRemove() {
-    setThumbnail('')
-    setIsButtonDisabled(true)
-    setKey((e) => e + 1)
-  }
-  // 이미지
+
   const onChangetitle = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault()
     setTitle(e.target.value)
@@ -56,57 +35,29 @@ export default function VideoBlockForm() {
 
   return (
     <div className={styles.container}>
-      <form onSubmit={submitHandler}>
-        <label>
-          <div className={styles.checkbox}>
-            <input type="radio" value="radio1" checked={selectedRadio === 'radio1'} onChange={handleRadioChange} />
-            <h3>동영상 URL 첨부*</h3>
-          </div>
-          <input
-            type="text"
-            value={title}
-            onChange={onChangetitle}
-            placeholder="동영상 주소를 입력해주세요."
-            disabled={selectedRadio !== 'radio1'}
-          />
-        </label>
-        <label>
-          <div className={styles.checkbox}>
-            <input type="radio" value="radio2" checked={selectedRadio === 'radio2'} onChange={handleRadioChange} />
-            <h3>동영상 파일 첨부</h3>
-          </div>
-          <label
-            htmlFor="file"
-            className={styles.addVideoButton}
-            style={selectedRadio !== 'radio2' ? { cursor: 'not-allowed' } : { cursor: 'pointer' }}
-          >
-            +
-          </label>
-          <input
-            type="file"
-            id="file"
-            name="file"
-            onChange={(e) => {
-              changeVideo(e)
-            }}
-            style={{ display: 'none' }}
-            disabled={selectedRadio !== 'radio2'}
-            key={key}
-          />
-          {thumbnail ? (
-            <div
-              className={styles.thumbnailVideo}
-              onClick={() => {
-                changeVideoRemove()
-              }}
-            >
-              <video src={thumbnail} />
-              <div className={styles.minus}>-</div>
+      <form className={styles.formBox} onSubmit={submitHandler}>
+        <div className={styles.forms}>
+          <label>
+            <div className={styles.checkbox}>
+              <input type="radio" value="radio1" checked={selectedRadio === 'radio1'} onChange={handleRadioChange} />
+              <h3>동영상 URL 첨부*</h3>
             </div>
-          ) : (
-            <div style={{ display: 'none' }} />
-          )}
-        </label>
+            <input
+              type="text"
+              value={title}
+              onChange={onChangetitle}
+              placeholder="동영상 주소를 입력해주세요."
+              disabled={selectedRadio !== 'radio1'}
+            />
+          </label>
+          <label>
+            <div className={styles.checkbox}>
+              <input type="radio" value="radio2" checked={selectedRadio === 'radio2'} onChange={handleRadioChange} />
+              <h3>동영상 파일 첨부</h3>
+            </div>
+          </label>
+          <Thumbnail radio={selectedRadio} imgData={setThumbnail} buttonActive={setIsButtonDisabled} />
+        </div>
         <FormButton title={'동영상 추가하기'} event={isButtonDisabled} />
       </form>
     </div>

--- a/src/components/Space/ActionBlockFormBase.module.scss
+++ b/src/components/Space/ActionBlockFormBase.module.scss
@@ -1,5 +1,6 @@
 .navigation {
   display: flex;
+  padding: 0 20px 0 20px;
 }
 
 .active {

--- a/src/components/Space/ActionBlockFormBase.tsx
+++ b/src/components/Space/ActionBlockFormBase.tsx
@@ -44,26 +44,28 @@ export function ActionBlockFormBase({ children }: Props) {
     }
   ]
   return (
-    <div>
-      <h1>{blockType} 추가하기</h1>
-      <div className={styles.navigation}>
-        {formTypes.map((form) => {
-          return (
-            <div key={form.type}>
-              <button
-                className={form.type === blockType ? styles.active : styles.inactive}
-                onClick={() => {
-                  setBlockType(form.type)
-                }}
-              >
-                <div>{form.icon}</div>
-                <div>{form.title}</div>
-              </button>
-            </div>
-          )
-        })}
+    <div style={{ display: 'flex', height: '100%', flexDirection: 'column' }}>
+      <div className={styles.container}>
+        <h1>{formTypes.find((form) => form.type === blockType)?.title} 추가하기</h1>
+        <div className={styles.navigation}>
+          {formTypes.map((form) => {
+            return (
+              <div key={form.type}>
+                <button
+                  className={form.type === blockType ? styles.active : styles.inactive}
+                  onClick={() => {
+                    setBlockType(form.type)
+                  }}
+                >
+                  <div>{form.icon}</div>
+                  <div>{form.title}</div>
+                </button>
+              </div>
+            )
+          })}
+        </div>
       </div>
-      <div>{children}</div>
+      <div style={{ display: 'flex', height: '100%', width: '100%' }}>{children}</div>
     </div>
   )
 }

--- a/src/components/Space/Drawer.tsx
+++ b/src/components/Space/Drawer.tsx
@@ -10,6 +10,7 @@ export function Drawer() {
     <AntdDrawer
       title="Basic AntdDrawer"
       placement="right"
+      bodyStyle={{ padding: '0' }}
       onClose={() => {
         setOpenDrawer(false)
       }}

--- a/src/components/Ui/Button.tsx
+++ b/src/components/Ui/Button.tsx
@@ -1,12 +1,11 @@
 import styles from './Button.module.scss'
 
-type FormButton = {
+export type FormButtonProps = {
   title: string
   event: boolean
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export default function FormButton({ title, event }: FormButton) {
+export default function FormButton({ title, event }: FormButtonProps) {
   return (
     <button className={event ? styles.disabledButton : styles.activeButton} disabled={event}>
       {title}

--- a/src/components/Ui/Thumbnail.module.scss
+++ b/src/components/Ui/Thumbnail.module.scss
@@ -1,0 +1,48 @@
+  .addVideoButton {
+    width: 100%;
+    display: flex;
+    cursor: pointer;
+    font-size: 2rem;
+    font-weight: 100;
+    height: 5.3125rem;
+    align-items: center;
+    border-radius: .375rem;
+    justify-content: center;
+    border: solid .0625rem #000000;
+  }
+  
+  .thumbnailVideo {
+    display: flex;
+    cursor: pointer;
+    overflow: hidden;
+    width: 5.3125rem;
+    height: 5.3125rem;
+    position: relative;
+    border-radius: .25rem;
+    img {
+      width: auto;
+      height: auto;
+    }
+    .minus {
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: none;
+      position: absolute;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+  
+  .thumbnailVideo:hover {
+    .minus {
+      display: flex;
+      background-color: rgba(0, 0, 0, 0.477);
+      svg {
+        font-size: 1.25rem;
+        border-radius: 100%;
+        background-color: white;
+      }
+    }
+  }

--- a/src/components/Ui/Thumbnail.tsx
+++ b/src/components/Ui/Thumbnail.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable multiline-ternary */
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+import { HiOutlineMinusCircle } from 'react-icons/hi'
+import styles from './Thumbnail.module.scss'
+
+type Props = {
+  radio?: string
+  imgData?: Dispatch<SetStateAction<string>>
+  buttonActive?: Dispatch<SetStateAction<boolean>>
+  img?: string
+}
+
+export default function Thumbnail({ radio, imgData, buttonActive, img }: Props) {
+  const [selectedRadio, setSelectedRadio] = useState<string>('radio1')
+  const [thumbnail, setThumbnail] = useState<string>('')
+  const [key, setKey] = useState(0)
+
+  useEffect(() => {
+    setSelectedRadio(radio ?? 'radio1')
+  }, [radio])
+
+  /** 제품 썸네일 이미지 Base64 포멧 변환 */
+  function changeMedia(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files as FileList
+    for (const file of files) {
+      const reader = new FileReader()
+      reader.readAsDataURL(file)
+      reader.addEventListener('load', (e) => {
+        const result = (e.target as FileReader).result as string
+        setThumbnail(result)
+        imgData && imgData(result)
+        setKey((e) => e + 1)
+      })
+    }
+    buttonActive && buttonActive(e.target.value === '')
+  }
+
+  /** 썸네일 이미지 삭제 기능 */
+  function changeMediaRemove() {
+    setThumbnail('')
+    imgData && imgData('')
+    buttonActive && buttonActive(true)
+    setKey((e) => e + 1)
+  }
+
+  return (
+    <>
+      <label
+        htmlFor="file"
+        className={styles.addVideoButton}
+        style={selectedRadio && img !== 'radio2' && img ? { cursor: 'not-allowed' } : { cursor: 'pointer' }}
+      >
+        +
+      </label>
+      <input
+        type="file"
+        id="file"
+        name="file"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          changeMedia(e)
+        }}
+        disabled={!!(selectedRadio && img !== 'radio2' && img)}
+        key={key}
+      />
+      {thumbnail ? (
+        <div
+          className={styles.thumbnailVideo}
+          onClick={() => {
+            changeMediaRemove()
+          }}
+        >
+          {thumbnail.includes('image') ? <img src={thumbnail} /> : <video src={thumbnail} />}
+          <div className={styles.minus}>
+            <HiOutlineMinusCircle />
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: selectedRadio !== 'radio2' ? 'none' : 'block' }} />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
# 요약
1. 동영상, 이미지 썸네일 이미지 기능 컴포넌트화
2. 동영상, 이미지, 링크 블록 스타일 수정
# 상세 설명
- [x] 폼 제출용 버튼 컴포넌트 만들기(애니메이션 효과 적용하기)
- [x] Drawer 폼 내부 Padding 지정 값 삭제
- [x] 폼 제출 후 input 및 상태 데이터 초기화
- [x] 미리보기 이미지 삭제 버튼 스타일 '리액트 아이콘' 사용
- [x] 동영상 URL 밎 파일업로드 라디오 버튼 선택 기능으로 선택되지 않는 버튼은 기능 비활성화
# 참고 
1. 블럭 스타일 수정
<img width="840" alt="스크린샷 2023-09-15 오후 8 24 55" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/106785596/4bdef182-5fdb-4ecb-8d2a-2853df68e0bf">
<img width="840" alt="스크린샷 2023-09-15 오후 8 25 05" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/106785596/a6d1c3fc-f924-49f7-a760-873e9a07bd72">

2. Darwer 영역 레이아웃 수정 및 썸네일 기능 컴포넌트화
<img width="424" alt="스크린샷 2023-09-15 오후 8 25 54" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/106785596/9e511ec5-9dde-4ba8-a621-2563ad7fa1d7">
<img width="424" alt="스크린샷 2023-09-15 오후 8 25 45" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/106785596/ea05f302-485b-4a13-a2c0-b555930a9826">
<img width="424" alt="스크린샷 2023-09-15 오후 8 25 29" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/106785596/cf01d6e2-0a22-4c7d-86e9-8b44942a675b">
