### PR TITLE
좌측 SideNavBar, SideListNar 전체 여닫히게 수정 #33

### DIFF
--- a/src/components/Layouts/Layout.tsx
+++ b/src/components/Layouts/Layout.tsx
@@ -1,6 +1,5 @@
 import { Header } from '@/components/Menus/Header'
 import { SideNavBar } from '@/components/Menus/SideNavBar'
-import { SpaceListBar } from '@/components/Menus/SpaceListBar'
 import { useUserStore } from '@/store/user'
 import { Layout as AntdLayout } from 'antd'
 import { useEffect, useState } from 'react'
@@ -43,12 +42,11 @@ export default function Layout() {
     <div>
       <div id="portal" />
       <AntdLayout style={{ background: '#fff' }}>
-        <SpaceListBar />
         <AntdLayout>
-          <Header collapsedChange={collapsedChange} collapsed={collapsed} />
           <AntdLayout className={styles.layout}>
             <SideNavBar collapsed={collapsed} />
             <Content>
+              <Header collapsedChange={collapsedChange} collapsed={collapsed} />
               <Outlet />
             </Content>
           </AntdLayout>

--- a/src/components/Menus/Header.tsx
+++ b/src/components/Menus/Header.tsx
@@ -1,4 +1,4 @@
-import { MenuFoldOutlined, MenuUnfoldOutlined } from '@ant-design/icons'
+import { LeftOutlined, RightOutlined } from '@ant-design/icons'
 import { Breadcrumb, Button, Layout } from 'antd'
 
 export function Header(props: any) {
@@ -7,7 +7,7 @@ export function Header(props: any) {
       <div style={{ display: 'flex', alignItems: 'center' }}>
       <Button
         type="text"
-        icon={props.collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+        icon={props.collapsed ? <RightOutlined /> : < LeftOutlined />}
         onClick={() => {
           props.collapsedChange(!props.collapsed)
         }}

--- a/src/components/Menus/Header.tsx
+++ b/src/components/Menus/Header.tsx
@@ -5,39 +5,38 @@ export function Header(props: any) {
   return (
     <Layout style={{ padding: 0, display: 'flex' }}>
       <div style={{ display: 'flex', alignItems: 'center' }}>
-      <Button
-        type="text"
-        icon={props.collapsed ? <RightOutlined /> : < LeftOutlined />}
-        onClick={() => {
-          props.collapsedChange(!props.collapsed)
-        }}
-        style={{
-          fontSize: '16px',
-          width: 64,
-          height: 64
-        }}
-      />
-      <Breadcrumb
-        separator=">"
-        items={[
-          {
-            title: 'Home'
-          },
-          {
-            title: 'Application Center',
-            href: ''
-          },
-          {
-            title: 'Application List',
-            href: ''
-          },
-          {
-            title: 'An Application'
-          }
-        ]}
-      />
+        <Button
+          type="text"
+          icon={props.collapsed ? <RightOutlined /> : <LeftOutlined />}
+          onClick={() => {
+            props.collapsedChange(!props.collapsed)
+          }}
+          style={{
+            fontSize: '16px',
+            width: 64,
+            height: 64
+          }}
+        />
+        <Breadcrumb
+          separator=">"
+          items={[
+            {
+              title: 'Home'
+            },
+            {
+              title: 'Application Center',
+              href: ''
+            },
+            {
+              title: 'Application List',
+              href: ''
+            },
+            {
+              title: 'An Application'
+            }
+          ]}
+        />
       </div>
-
     </Layout>
   )
 }

--- a/src/components/Menus/SideNavBar.tsx
+++ b/src/components/Menus/SideNavBar.tsx
@@ -1,5 +1,7 @@
+import { SpaceListBar } from '@/components/Menus/SpaceListBar'
+import { UserOutlined } from '@ant-design/icons'
 import type { MenuProps } from 'antd'
-import { Button, Layout, Menu, Space } from 'antd'
+import { Avatar, Button, Layout, Menu, Space } from 'antd'
 
 const { Sider } = Layout
 
@@ -8,13 +10,11 @@ type MenuItem = Required<MenuProps>['items'][number]
 function getItem(
   label: React.ReactNode,
   key: React.Key,
-  icon?: React.ReactNode,
   children?: MenuItem[],
   type?: 'group'
 ): MenuItem {
   return {
     key,
-    icon,
     children,
     label,
     type
@@ -22,21 +22,20 @@ function getItem(
 }
 
 const items: MenuProps['items'] = [
-  getItem(
-    '연락처 그룹',
-    '연락처 그룹',
-    null,
-    [getItem('전체보기', '전체보기'), getItem('임직원', '임직원'), getItem('관계자', '관계자')],
-    'group'
-  ),
-  getItem(
-    '문서보관함',
-    '문서보관함',
-    null,
-    [getItem('발신함', '발신함'), getItem('수신함', '수신함'), getItem('보관 문서함', '보관 문서함')],
-    'group'
-  ),
-  getItem('관리및문의', '관리및문의', null, [], 'group')
+  getItem('연락처 그룹', '연락처 그룹', [
+    getItem('전체보기', '전체보기'),
+    getItem('임직원', '임직원'),
+    getItem('관계자', '관계자')
+  ]),
+  getItem('문서보관함', '문서보관함', [
+    getItem('발신함', '발신함'),
+    getItem('수신함', '수신함'),
+    getItem('보관 문서함', '보관 문서함')
+  ]),
+  getItem('관리및문의', '관리및문의', [
+    getItem('어쩌구', '어쩌구'),
+    getItem('저쩌구', '수신함')
+  ])
 ]
 
 export function SideNavBar(props: any) {
@@ -46,14 +45,27 @@ export function SideNavBar(props: any) {
       collapsible
       collapsed={props.collapsed}
       collapsedWidth="0"
-      style={{ backgroundColor: 'white' }}
+      style={{ backgroundColor: '#fff', display: 'flex', flexDirection: 'column' }}
     >
-      <Space className="site-button-ghost-wrapper" wrap direction="horizontal">
-        <Button>문서보내기</Button>
-        <Button>연락처추가</Button>
-      </Space>
-      <Button block>공유페이지</Button>
-      <Menu mode="inline" defaultSelectedKeys={['1']} items={items} />
+      <div style={{ display: 'flex' }}>
+        <SpaceListBar />
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', width: '80%', margin: '0 auto' }}>
+            <Space direction="vertical" style={{ marginTop: '20px' }}>
+              <Avatar
+                size={{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }}
+                icon={<UserOutlined />}
+                style={{ backgroundColor: '#4C61FF' }}
+              />
+            </Space>
+            <h2 style={{ margin: 'none' }}>주하림</h2>
+            <Button style={{ backgroundColor: '#4C61FF', color: '#FFFFFF', border: 'none' }} block>공유페이지</Button>
+            <Button style={{ backgroundColor: '#ECECFB', color: '#4C61FF', border: 'none' }} block>문서보내기</Button>
+            <Button style={{ backgroundColor: '#ECECFB', color: '#4C61FF', border: 'none' }} block>연락처추가</Button>
+          </div>
+          <Menu mode="inline" defaultSelectedKeys={['1']} items={items} />
+        </div>
+      </div>
     </Sider>
   )
 }

--- a/src/components/Menus/SideNavBar.tsx
+++ b/src/components/Menus/SideNavBar.tsx
@@ -7,12 +7,7 @@ const { Sider } = Layout
 
 type MenuItem = Required<MenuProps>['items'][number]
 
-function getItem(
-  label: React.ReactNode,
-  key: React.Key,
-  children?: MenuItem[],
-  type?: 'group'
-): MenuItem {
+function getItem(label: React.ReactNode, key: React.Key, children?: MenuItem[], type?: 'group'): MenuItem {
   return {
     key,
     children,
@@ -32,10 +27,7 @@ const items: MenuProps['items'] = [
     getItem('수신함', '수신함'),
     getItem('보관 문서함', '보관 문서함')
   ]),
-  getItem('관리및문의', '관리및문의', [
-    getItem('어쩌구', '어쩌구'),
-    getItem('저쩌구', '수신함')
-  ])
+  getItem('관리및문의', '관리및문의', [getItem('어쩌구', '어쩌구'), getItem('저쩌구', '수신함')])
 ]
 
 export function SideNavBar(props: any) {
@@ -50,7 +42,16 @@ export function SideNavBar(props: any) {
       <div style={{ display: 'flex' }}>
         <SpaceListBar />
         <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', width: '80%', margin: '0 auto' }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '80%',
+              margin: '0 auto'
+            }}
+          >
             <Space direction="vertical" style={{ marginTop: '20px' }}>
               <Avatar
                 size={{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }}
@@ -59,9 +60,15 @@ export function SideNavBar(props: any) {
               />
             </Space>
             <h2 style={{ margin: 'none' }}>주하림</h2>
-            <Button style={{ backgroundColor: '#4C61FF', color: '#FFFFFF', border: 'none' }} block>공유페이지</Button>
-            <Button style={{ backgroundColor: '#ECECFB', color: '#4C61FF', border: 'none' }} block>문서보내기</Button>
-            <Button style={{ backgroundColor: '#ECECFB', color: '#4C61FF', border: 'none' }} block>연락처추가</Button>
+            <Button style={{ backgroundColor: '#4C61FF', color: '#FFFFFF', border: 'none' }} block>
+              공유페이지
+            </Button>
+            <Button style={{ backgroundColor: '#ECECFB', color: '#4C61FF', border: 'none' }} block>
+              문서보내기
+            </Button>
+            <Button style={{ backgroundColor: '#ECECFB', color: '#4C61FF', border: 'none' }} block>
+              연락처추가
+            </Button>
           </div>
           <Menu mode="inline" defaultSelectedKeys={['1']} items={items} />
         </div>

--- a/src/components/Menus/SpaceListBar.tsx
+++ b/src/components/Menus/SpaceListBar.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Layout, Tabs } from 'antd'
+import { Avatar, ConfigProvider, Layout, Tabs } from 'antd'
 
 const { Sider } = Layout
 
@@ -9,21 +9,30 @@ const siderStyle: React.CSSProperties = {
 
 export function SpaceListBar() {
   return (
-    <Sider width={100} style={siderStyle} collapsible>
-      <Tabs
-        tabPosition={'left'}
-        items={new Array(3).fill(null).map((_, i) => {
-          const id = String(i + 1)
-          return {
-            label: (
-              <Avatar size={50} shape="square" style={{ backgroundColor: '#292D32' }}>
-                {id}
-              </Avatar>
-            ),
-            key: id
+    <Sider width={65} style={siderStyle}>
+      <ConfigProvider
+        theme={{
+          token: {
+            colorPrimary: '#fff'
           }
-        })}
-      />
+        }}
+      >
+      <Tabs
+          tabPosition={'left'}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+          items={new Array(3).fill(null).map((_, i) => {
+            const id = String(i + 1)
+            return {
+              label: (
+                <Avatar size={50} shape="square" style={{ backgroundColor: '#292D32' }}>
+                  {id}
+                </Avatar>
+              ),
+              key: id
+            }
+          })}
+        />
+      </ConfigProvider>
     </Sider>
   )
 }

--- a/src/components/Menus/SpaceListBar.tsx
+++ b/src/components/Menus/SpaceListBar.tsx
@@ -17,7 +17,7 @@ export function SpaceListBar() {
           }
         }}
       >
-      <Tabs
+        <Tabs
           tabPosition={'left'}
           style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
           items={new Array(3).fill(null).map((_, i) => {


### PR DESCRIPTION
# 요약

좌측 SideNavBar, SideListBar 전체 여닫히게 수정

# 상세 설명

모바일, 웹 동일하게 SideNavBar, SideListBar 전체가 여닫히게 수정했습니다.

# 참고 

모바일, 웹 똑같이 전체 여/닫히게 수정되어서, 피그마에 있는 스타일대로(SideListBar은 안닫히고 그대로 있는) 만들지 않았습니다. 참고 부탁드려용
