### PR TITLE
SSR 및 hydration 이후 react 내부 페이지 이동 처리

### DIFF
--- a/mocks/development/logo.json
+++ b/mocks/development/logo.json
@@ -1,166 +1,166 @@
 {
-    "deaflut_logo" : [
-        {
-            "logo_id": "textlogo",
-            "src" : "",
-            "alt" : "텍스트블록"
-        }
-    ],
-    "logo" : [
-        {
-            "logo_id": "band",
-            "src" : "public/BlockLogo/band.png",
-            "alt" : "네이버밴드"
-        },
-        {
-            "logo_id": "brunch",
-            "src" : "public/BlockLogo/brunch.png",
-            "alt" : "브런치"
-        },
-        {
-            "logo_id": "bunjang",
-            "src" : "public/BlockLogo/bunjang.png",
-            "alt" : "번개장터"
-        },
-        {
-            "logo_id": "chatgpt",
-            "src" : "public/BlockLogo/chatgpt.png",
-            "alt" : "챗GPT"
-        },
-        {
-            "logo_id": "coupang",
-            "src" : "public/BlockLogo/coupang.png",
-            "alt" : "쿠팡"
-        },
-        {
-            "logo_id": "daangn",
-            "src" : "public/BlockLogo/daangn.png",
-            "alt" : "당근마켓"
-        },
-        {
-            "logo_id": "daum",
-            "src" : "public/BlockLogo/daum.png",
-            "alt" : "다음"
-        },
-        {
-            "logo_id": "default",
-            "src" : "public/BlockLogo/default.png",
-            "alt" : "기본값"
-        },
-        {
-            "logo_id": "discord",
-            "src" : "public/BlockLogo/discord.png",
-            "alt" : "디스코드"
-        },
-        {
-            "logo_id": "facebook_messenger",
-            "src" : "public/BlockLogo/facebook_messenger.png",
-            "alt" : "페이스북메신저"
-        },
-        {
-            "logo_id": "facebook",
-            "src" : "public/BlockLogo/facebook.png",
-            "alt" : "페이스북"
-        },
-        {
-            "logo_id": "gmarket",
-            "src" : "public/BlockLogo/gmarket.png",
-            "alt" : "지마켓"
-        },
-        {
-            "logo_id": "google_maps",
-            "src" : "public/BlockLogo/google_maps.png",
-            "alt" : "구글맵스"
-        },
-        {
-            "logo_id": "google",
-            "src" : "public/BlockLogo/google.png",
-            "alt" : "구글"
-        },
-        {
-            "logo_id": "jober",
-            "src" : "public/BlockLogo/jober.png",
-            "alt" : "자버"
-        },
-        {
-            "logo_id": "band",
-            "src" : "public/BlockLogo/band.png",
-            "alt" : "네이버밴드"
-        },
-        {
-            "logo_id": "kakao",
-            "src" : "public/BlockLogo/kakao.png",
-            "alt" : "카카오톡"
-        },
-        {
-            "logo_id": "line",
-            "src" : "public/BlockLogo/line.png",
-            "alt" : "라인"
-        },
-        {
-            "logo_id": "modoo",
-            "src" : "public/BlockLogo/modoo.png",
-            "alt" : "모두"
-        },
-        {
-            "logo_id": "naver_blog",
-            "src" : "public/BlockLogo/naver_blog.png",
-            "alt" : "네이버블로그"
-        },
-        {
-            "logo_id": "naver",
-            "src" : "public/BlockLogo/naver.png",
-            "alt" : "네이버"
-        },
-        {
-            "logo_id": "notion",
-            "src" : "public/BlockLogo/notion.png",
-            "alt" : "노션"
-        },
-        {
-            "logo_id": "slack",
-            "src" : "public/BlockLogo/slack.png",
-            "alt" : "슬랙"
-        },
-        {
-            "logo_id": "smartstore",
-            "src" : "public/BlockLogo/smartstore.png",
-            "alt" : "스마트스토어"
-        },
-        {
-            "logo_id": "tiktok",
-            "src" : "public/BlockLogo/tiktok.png",
-            "alt" : "틱톡"
-        },
-        {
-            "logo_id": "tistory",
-            "src" : "public/BlockLogo/tistory_blog.png",
-            "alt" : "티스토리"
-        },
-        {
-            "logo_id": "twitter",
-            "src" : "public/BlockLogo/twitter.png",
-            "alt" : "트위터"
-        },
-        {
-            "logo_id": "vlog",
-            "src" : "public/BlockLogo/vlog.png",
-            "alt" : "벨로그"
-        },
-        {
-            "logo_id": "wordpress",
-            "src" : "public/BlockLogo/wordpress.png",
-            "alt" : "워드프레스"
-        },
-        {
-            "logo_id": "youtube",
-            "src" : "public/BlockLogo/youtube.png",
-            "alt" : "유튜브"
-        },
-        {
-            "logo_id": "zoom",
-            "src" : "public/BlockLogo/zoom.png",
-            "alt" : "줌"
-        }
-    ]
+  "deaflut_logo": [
+    {
+      "logo_id": "textlogo",
+      "src": "",
+      "alt": "텍스트블록"
+    }
+  ],
+  "logo": [
+    {
+      "logo_id": "band",
+      "src": "/BlockLogo/band.png",
+      "alt": "네이버밴드"
+    },
+    {
+      "logo_id": "brunch",
+      "src": "/BlockLogo/brunch.png",
+      "alt": "브런치"
+    },
+    {
+      "logo_id": "bunjang",
+      "src": "/BlockLogo/bunjang.png",
+      "alt": "번개장터"
+    },
+    {
+      "logo_id": "chatgpt",
+      "src": "/BlockLogo/chatgpt.png",
+      "alt": "챗GPT"
+    },
+    {
+      "logo_id": "coupang",
+      "src": "/BlockLogo/coupang.png",
+      "alt": "쿠팡"
+    },
+    {
+      "logo_id": "daangn",
+      "src": "/BlockLogo/daangn.png",
+      "alt": "당근마켓"
+    },
+    {
+      "logo_id": "daum",
+      "src": "/BlockLogo/daum.png",
+      "alt": "다음"
+    },
+    {
+      "logo_id": "default",
+      "src": "/BlockLogo/default.png",
+      "alt": "기본값"
+    },
+    {
+      "logo_id": "discord",
+      "src": "/BlockLogo/discord.png",
+      "alt": "디스코드"
+    },
+    {
+      "logo_id": "facebook_messenger",
+      "src": "/BlockLogo/facebook_messenger.png",
+      "alt": "페이스북메신저"
+    },
+    {
+      "logo_id": "facebook",
+      "src": "/BlockLogo/facebook.png",
+      "alt": "페이스북"
+    },
+    {
+      "logo_id": "gmarket",
+      "src": "/BlockLogo/gmarket.png",
+      "alt": "지마켓"
+    },
+    {
+      "logo_id": "google_maps",
+      "src": "/BlockLogo/google_maps.png",
+      "alt": "구글맵스"
+    },
+    {
+      "logo_id": "google",
+      "src": "/BlockLogo/google.png",
+      "alt": "구글"
+    },
+    {
+      "logo_id": "jober",
+      "src": "/BlockLogo/jober.png",
+      "alt": "자버"
+    },
+    {
+      "logo_id": "band",
+      "src": "/BlockLogo/band.png",
+      "alt": "네이버밴드"
+    },
+    {
+      "logo_id": "kakao",
+      "src": "/BlockLogo/kakao.png",
+      "alt": "카카오톡"
+    },
+    {
+      "logo_id": "line",
+      "src": "/BlockLogo/line.png",
+      "alt": "라인"
+    },
+    {
+      "logo_id": "modoo",
+      "src": "/BlockLogo/modoo.png",
+      "alt": "모두"
+    },
+    {
+      "logo_id": "naver_blog",
+      "src": "/BlockLogo/naver_blog.png",
+      "alt": "네이버블로그"
+    },
+    {
+      "logo_id": "naver",
+      "src": "/BlockLogo/naver.png",
+      "alt": "네이버"
+    },
+    {
+      "logo_id": "notion",
+      "src": "/BlockLogo/notion.png",
+      "alt": "노션"
+    },
+    {
+      "logo_id": "slack",
+      "src": "/BlockLogo/slack.png",
+      "alt": "슬랙"
+    },
+    {
+      "logo_id": "smartstore",
+      "src": "/BlockLogo/smartstore.png",
+      "alt": "스마트스토어"
+    },
+    {
+      "logo_id": "tiktok",
+      "src": "/BlockLogo/tiktok.png",
+      "alt": "틱톡"
+    },
+    {
+      "logo_id": "tistory",
+      "src": "/BlockLogo/tistory_blog.png",
+      "alt": "티스토리"
+    },
+    {
+      "logo_id": "twitter",
+      "src": "/BlockLogo/twitter.png",
+      "alt": "트위터"
+    },
+    {
+      "logo_id": "vlog",
+      "src": "/BlockLogo/vlog.png",
+      "alt": "벨로그"
+    },
+    {
+      "logo_id": "wordpress",
+      "src": "/BlockLogo/wordpress.png",
+      "alt": "워드프레스"
+    },
+    {
+      "logo_id": "youtube",
+      "src": "/BlockLogo/youtube.png",
+      "alt": "유튜브"
+    },
+    {
+      "logo_id": "zoom",
+      "src": "/BlockLogo/zoom.png",
+      "alt": "줌"
+    }
+  ]
 }

--- a/mocks/development/space.json
+++ b/mocks/development/space.json
@@ -1,7 +1,103 @@
 {
-  "user1": {
-    "title": "foo",
-    "description": "bar",
+  "space1": {
+    "spaceId": "space1",
+    "profileImage": "http://localhost:5173/profile_1.png",
+    "title": "user1의 스페이스",
+    "description": "안녕하세요",
+    "blocks": [
+      {
+        "blockId": "block_1_1",
+        "y": 0,
+        "x": 0,
+        "h": 1,
+        "w": 2,
+        "type": "link",
+        "url": "http://www.naver.com",
+        "text": "네이버",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_2",
+        "y": 1,
+        "x": 0,
+        "h": 1,
+        "w": 2,
+        "type": "link",
+        "url": "http://www.youtube.com",
+        "text": "유튜브",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_3",
+        "y": 0,
+        "x": 2,
+        "h": 2,
+        "w": 2,
+        "type": "image",
+        "src": "http://localhost:5173/img2.jpg",
+        "alt": "춤추는 인간2",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_4",
+        "y": 2,
+        "x": 0,
+        "h": 1,
+        "w": 4,
+        "type": "page",
+        "text": "하위 공유 페이지로 이동하기",
+        "url": "http://www.naver.com",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_5",
+        "y": 3,
+        "x": 0,
+        "h": 1,
+        "w": 4,
+        "type": "text",
+        "text": "the quick brown fox jumps over the lazy dog",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_6",
+        "y": 4,
+        "x": 0,
+        "h": 2,
+        "w": 2,
+        "type": "video",
+        "src": "https://www.youtube.com/embed/75kySTFaBQQ",
+        "caption": "yotube playlist 이거 필요없을 거 같인한데, bento처럼 사용자가 캡션을 원할 경우 추가",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_7",
+        "y": 4,
+        "x": 2,
+        "h": 2,
+        "w": 2,
+        "type": "video",
+        "src": "http://localhost:5173/test.mp4",
+        "caption": "쓸모없는 비디오",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_8",
+        "y": 6,
+        "x": 0,
+        "h": 2,
+        "w": 2,
+        "type": "googleMap",
+        "src": "https://www.google.com/maps/embed/v1/place?key=AIzaSyCnJyiI_VgJmszJ9ceC-AKCVN7ebJe8ovo&q=Eiffel+Tower,Paris+France",
+        "visible": false
+      }
+    ]
+  },
+  "space2": {
+    "spaceId": "space2",
+    "profileImage": "http://localhost:5173/profile_2.jpg",
+    "title": "user2의 최상위 페이지",
+    "description": "어쩌고 저쩌고 ㅎㅎ",
     "blocks": [
       {
         "blockId": "block_1_1",

--- a/mocks/production/logo.json
+++ b/mocks/production/logo.json
@@ -1,166 +1,166 @@
 {
-    "deaflut_logo" : [
-        {
-            "logo_id": "textlogo",
-            "src" : "",
-            "alt" : "텍스트블록"
-        }
-    ],
-    "logo" : [
-        {
-            "logo_id": "band",
-            "src" : "public/BlockLogo/band.png",
-            "alt" : "네이버밴드"
-        },
-        {
-            "logo_id": "brunch",
-            "src" : "public/BlockLogo/brunch.png",
-            "alt" : "브런치"
-        },
-        {
-            "logo_id": "bunjang",
-            "src" : "public/BlockLogo/bunjang.png",
-            "alt" : "번개장터"
-        },
-        {
-            "logo_id": "chatgpt",
-            "src" : "public/BlockLogo/chatgpt.png",
-            "alt" : "챗GPT"
-        },
-        {
-            "logo_id": "coupang",
-            "src" : "public/BlockLogo/coupang.png",
-            "alt" : "쿠팡"
-        },
-        {
-            "logo_id": "daangn",
-            "src" : "public/BlockLogo/daangn.png",
-            "alt" : "당근마켓"
-        },
-        {
-            "logo_id": "daum",
-            "src" : "public/BlockLogo/daum.png",
-            "alt" : "다음"
-        },
-        {
-            "logo_id": "default",
-            "src" : "public/BlockLogo/default.png",
-            "alt" : "기본값"
-        },
-        {
-            "logo_id": "discord",
-            "src" : "public/BlockLogo/discord.png",
-            "alt" : "디스코드"
-        },
-        {
-            "logo_id": "facebook_messenger",
-            "src" : "public/BlockLogo/facebook_messenger.png",
-            "alt" : "페이스북메신저"
-        },
-        {
-            "logo_id": "facebook",
-            "src" : "public/BlockLogo/facebook.png",
-            "alt" : "페이스북"
-        },
-        {
-            "logo_id": "gmarket",
-            "src" : "public/BlockLogo/gmarket.png",
-            "alt" : "지마켓"
-        },
-        {
-            "logo_id": "google_maps",
-            "src" : "public/BlockLogo/google_maps.png",
-            "alt" : "구글맵스"
-        },
-        {
-            "logo_id": "google",
-            "src" : "public/BlockLogo/google.png",
-            "alt" : "구글"
-        },
-        {
-            "logo_id": "jober",
-            "src" : "public/BlockLogo/jober.png",
-            "alt" : "자버"
-        },
-        {
-            "logo_id": "band",
-            "src" : "public/BlockLogo/band.png",
-            "alt" : "네이버밴드"
-        },
-        {
-            "logo_id": "kakao",
-            "src" : "public/BlockLogo/kakao.png",
-            "alt" : "카카오톡"
-        },
-        {
-            "logo_id": "line",
-            "src" : "public/BlockLogo/line.png",
-            "alt" : "라인"
-        },
-        {
-            "logo_id": "modoo",
-            "src" : "public/BlockLogo/modoo.png",
-            "alt" : "모두"
-        },
-        {
-            "logo_id": "naver_blog",
-            "src" : "public/BlockLogo/naver_blog.png",
-            "alt" : "네이버블로그"
-        },
-        {
-            "logo_id": "naver",
-            "src" : "public/BlockLogo/naver.png",
-            "alt" : "네이버"
-        },
-        {
-            "logo_id": "notion",
-            "src" : "public/BlockLogo/notion.png",
-            "alt" : "노션"
-        },
-        {
-            "logo_id": "slack",
-            "src" : "public/BlockLogo/slack.png",
-            "alt" : "슬랙"
-        },
-        {
-            "logo_id": "smartstore",
-            "src" : "public/BlockLogo/smartstore.png",
-            "alt" : "스마트스토어"
-        },
-        {
-            "logo_id": "tiktok",
-            "src" : "public/BlockLogo/tiktok.png",
-            "alt" : "틱톡"
-        },
-        {
-            "logo_id": "tistory",
-            "src" : "public/BlockLogo/tistory_blog.png",
-            "alt" : "티스토리"
-        },
-        {
-            "logo_id": "twitter",
-            "src" : "public/BlockLogo/twitter.png",
-            "alt" : "트위터"
-        },
-        {
-            "logo_id": "vlog",
-            "src" : "public/BlockLogo/vlog.png",
-            "alt" : "벨로그"
-        },
-        {
-            "logo_id": "wordpress",
-            "src" : "public/BlockLogo/wordpress.png",
-            "alt" : "워드프레스"
-        },
-        {
-            "logo_id": "youtube",
-            "src" : "public/BlockLogo/youtube.png",
-            "alt" : "유튜브"
-        },
-        {
-            "logo_id": "zoom",
-            "src" : "public/BlockLogo/zoom.png",
-            "alt" : "줌"
-        }
-    ]
+  "deaflut_logo": [
+    {
+      "logo_id": "textlogo",
+      "src": "",
+      "alt": "텍스트블록"
+    }
+  ],
+  "logo": [
+    {
+      "logo_id": "band",
+      "src": "/BlockLogo/band.png",
+      "alt": "네이버밴드"
+    },
+    {
+      "logo_id": "brunch",
+      "src": "/BlockLogo/brunch.png",
+      "alt": "브런치"
+    },
+    {
+      "logo_id": "bunjang",
+      "src": "/BlockLogo/bunjang.png",
+      "alt": "번개장터"
+    },
+    {
+      "logo_id": "chatgpt",
+      "src": "/BlockLogo/chatgpt.png",
+      "alt": "챗GPT"
+    },
+    {
+      "logo_id": "coupang",
+      "src": "/BlockLogo/coupang.png",
+      "alt": "쿠팡"
+    },
+    {
+      "logo_id": "daangn",
+      "src": "/BlockLogo/daangn.png",
+      "alt": "당근마켓"
+    },
+    {
+      "logo_id": "daum",
+      "src": "/BlockLogo/daum.png",
+      "alt": "다음"
+    },
+    {
+      "logo_id": "default",
+      "src": "/BlockLogo/default.png",
+      "alt": "기본값"
+    },
+    {
+      "logo_id": "discord",
+      "src": "/BlockLogo/discord.png",
+      "alt": "디스코드"
+    },
+    {
+      "logo_id": "facebook_messenger",
+      "src": "/BlockLogo/facebook_messenger.png",
+      "alt": "페이스북메신저"
+    },
+    {
+      "logo_id": "facebook",
+      "src": "/BlockLogo/facebook.png",
+      "alt": "페이스북"
+    },
+    {
+      "logo_id": "gmarket",
+      "src": "/BlockLogo/gmarket.png",
+      "alt": "지마켓"
+    },
+    {
+      "logo_id": "google_maps",
+      "src": "/BlockLogo/google_maps.png",
+      "alt": "구글맵스"
+    },
+    {
+      "logo_id": "google",
+      "src": "/BlockLogo/google.png",
+      "alt": "구글"
+    },
+    {
+      "logo_id": "jober",
+      "src": "/BlockLogo/jober.png",
+      "alt": "자버"
+    },
+    {
+      "logo_id": "band",
+      "src": "/BlockLogo/band.png",
+      "alt": "네이버밴드"
+    },
+    {
+      "logo_id": "kakao",
+      "src": "/BlockLogo/kakao.png",
+      "alt": "카카오톡"
+    },
+    {
+      "logo_id": "line",
+      "src": "/BlockLogo/line.png",
+      "alt": "라인"
+    },
+    {
+      "logo_id": "modoo",
+      "src": "/BlockLogo/modoo.png",
+      "alt": "모두"
+    },
+    {
+      "logo_id": "naver_blog",
+      "src": "/BlockLogo/naver_blog.png",
+      "alt": "네이버블로그"
+    },
+    {
+      "logo_id": "naver",
+      "src": "/BlockLogo/naver.png",
+      "alt": "네이버"
+    },
+    {
+      "logo_id": "notion",
+      "src": "/BlockLogo/notion.png",
+      "alt": "노션"
+    },
+    {
+      "logo_id": "slack",
+      "src": "/BlockLogo/slack.png",
+      "alt": "슬랙"
+    },
+    {
+      "logo_id": "smartstore",
+      "src": "/BlockLogo/smartstore.png",
+      "alt": "스마트스토어"
+    },
+    {
+      "logo_id": "tiktok",
+      "src": "/BlockLogo/tiktok.png",
+      "alt": "틱톡"
+    },
+    {
+      "logo_id": "tistory",
+      "src": "/BlockLogo/tistory_blog.png",
+      "alt": "티스토리"
+    },
+    {
+      "logo_id": "twitter",
+      "src": "/BlockLogo/twitter.png",
+      "alt": "트위터"
+    },
+    {
+      "logo_id": "vlog",
+      "src": "/BlockLogo/vlog.png",
+      "alt": "벨로그"
+    },
+    {
+      "logo_id": "wordpress",
+      "src": "/BlockLogo/wordpress.png",
+      "alt": "워드프레스"
+    },
+    {
+      "logo_id": "youtube",
+      "src": "/BlockLogo/youtube.png",
+      "alt": "유튜브"
+    },
+    {
+      "logo_id": "zoom",
+      "src": "/BlockLogo/zoom.png",
+      "alt": "줌"
+    }
+  ]
 }

--- a/mocks/production/space.json
+++ b/mocks/production/space.json
@@ -1,5 +1,7 @@
 {
-  "user1": {
+  "space1": {
+    "spaceId": "space1",
+    "profileImage": "http://ec2-34-228-10-85.compute-1.amazonaws.com/profile_1.png",
     "title": "foo",
     "description": "bar",
     "blocks": [
@@ -11,7 +13,7 @@
         "w": 2,
         "type": "link",
         "url": "http://www.naver.com",
-        "text": "네이버로 이동!",
+        "text": "네이버",
         "visible": false
       },
       {
@@ -20,9 +22,9 @@
         "x": 0,
         "h": 1,
         "w": 2,
-        "type": "image",
-        "src": "http://ec2-34-228-10-85.compute-1.amazonaws.com/img1.jpg",
-        "alt": "춤추는 인간",
+        "type": "link",
+        "url": "http://www.youtube.com",
+        "text": "유튜브",
         "visible": false
       },
       {
@@ -57,15 +59,108 @@
         "text": "the quick brown fox jumps over the lazy dog",
         "visible": false
       },
-
       {
         "blockId": "block_1_6",
         "y": 4,
         "x": 0,
         "h": 2,
         "w": 2,
-        "type": "embed",
-        "src": "https://www.youtube.com/embed/75kySTFaBQQ??si=w_qvmC6yYxwunlu0&wmode=opaque",
+        "type": "video",
+        "src": "https://www.youtube.com/embed/75kySTFaBQQ",
+        "caption": "yotube playlist 이거 필요없을 거 같인한데, bento처럼 사용자가 캡션을 원할 경우 추가",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_7",
+        "y": 4,
+        "x": 2,
+        "h": 2,
+        "w": 2,
+        "type": "video",
+        "src": "http://ec2-34-228-10-85.compute-1.amazonaws.com/test.mp4",
+        "caption": "쓸모없는 비디오",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_8",
+        "y": 6,
+        "x": 0,
+        "h": 2,
+        "w": 2,
+        "type": "googleMap",
+        "src": "https://www.google.com/maps/embed/v1/place?key=AIzaSyCnJyiI_VgJmszJ9ceC-AKCVN7ebJe8ovo&q=Eiffel+Tower,Paris+France",
+        "visible": false
+      }
+    ]
+  },
+  "space2": {
+    "spaceId": "space2",
+    "profileImage": "http://ec2-34-228-10-85.compute-1.amazonaws.com/profile_2.jpg",
+    "title": "user2의 최상위 페이지",
+    "description": "어쩌고 저쩌고 ㅎㅎ",
+    "blocks": [
+      {
+        "blockId": "block_1_1",
+        "y": 0,
+        "x": 0,
+        "h": 1,
+        "w": 2,
+        "type": "link",
+        "url": "http://www.naver.com",
+        "text": "네이버",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_2",
+        "y": 1,
+        "x": 0,
+        "h": 1,
+        "w": 2,
+        "type": "link",
+        "url": "http://www.youtube.com",
+        "text": "유튜브",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_3",
+        "y": 0,
+        "x": 2,
+        "h": 2,
+        "w": 2,
+        "type": "image",
+        "src": "http://ec2-34-228-10-85.compute-1.amazonaws.com/img2.jpg",
+        "alt": "춤추는 인간2",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_4",
+        "y": 2,
+        "x": 0,
+        "h": 1,
+        "w": 4,
+        "type": "page",
+        "text": "하위 공유 페이지로 이동하기",
+        "url": "http://www.naver.com",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_5",
+        "y": 3,
+        "x": 0,
+        "h": 1,
+        "w": 4,
+        "type": "text",
+        "text": "the quick brown fox jumps over the lazy dog",
+        "visible": false
+      },
+      {
+        "blockId": "block_1_6",
+        "y": 4,
+        "x": 0,
+        "h": 2,
+        "w": 2,
+        "type": "video",
+        "src": "https://www.youtube.com/embed/75kySTFaBQQ",
         "caption": "yotube playlist 이거 필요없을 거 같인한데, bento처럼 사용자가 캡션을 원할 경우 추가",
         "visible": false
       },

--- a/server/render/render.tsx
+++ b/server/render/render.tsx
@@ -1,5 +1,5 @@
 import App from '@/App'
-import { POST_API_KEY, SEO } from '@/constants'
+import { POST_API_KEY, SEO, SPACE } from '@/constants'
 import { SSRProvider } from '@/context/ssr'
 import { ChunkExtractor } from '@loadable/server'
 import type { Request, Response } from 'express'
@@ -7,6 +7,7 @@ import path from 'path'
 import { renderToString } from 'react-dom/server'
 import { Helmet } from 'react-helmet'
 import { StaticRouter } from 'react-router-dom/server'
+import { getSpaceBySpaceId } from '~/utils/getSpaceById'
 
 export default async function renderHome(url: string, req: Request, res: Response) {
   const serverSideData: Record<string, unknown> = {}
@@ -32,6 +33,11 @@ export default async function renderHome(url: string, req: Request, res: Respons
       '/detail': 'jober chip | 누군가의 디테일 페이지'
     }
   })
+  serverSideData[SPACE] = JSON.stringify({}) // CSR시 빈 객체로 초기화
+  if (url.includes('/space/')) {
+    const spaceId = url.split('/space/')[1]
+    serverSideData[SPACE] = JSON.stringify(getSpaceBySpaceId(spaceId))
+  }
 
   const webStats = path.resolve(__dirname, './web/loadable-stats.json')
   const nodeStats = path.resolve(__dirname, './node/loadable-stats.json')

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -51,4 +51,8 @@ authRouter.post('/signin', (req, res) => {
   return res.json(data[body.email])
 })
 
+authRouter.get('/space', (req, res) => {
+  res.send('')
+})
+
 export default authRouter

--- a/server/routes/space.ts
+++ b/server/routes/space.ts
@@ -23,17 +23,10 @@ spaceRouter.get('/', (req, res) => {
     return res.status(400).json({ message: 'Invalid user id' })
   }
   // * Privilege check
-  // 원래는 access token을 통해 privilege를 체크해야 하지만, mock data이므로 특정 아이디에 대해서만 제한
-  if (userId === 'user2') {
-    data[userId].previlige = {
-      edit: false,
-      delete: false
-    }
-  } else {
-    data[userId].previlige = {
-      edit: true,
-      delete: true
-    }
+  // previlige는 항상 false이고, 사용자 정보를 기반으로 previlige를 변경합니다.
+  data[userId].previlige = {
+    edit: false,
+    delete: false
   }
 
   return res.status(200).json(data[userId])

--- a/server/utils/getSpaceById.ts
+++ b/server/utils/getSpaceById.ts
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+type Previlige = {
+  edit: boolean
+  delete: boolean
+}
+type SpaceMockData = Record<string, { previlige: Previlige }>
+
+export function getSpaceBySpaceId(spaceId: string) {
+  const data: SpaceMockData = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, `../mocks/${process.env.NODE_ENV}/space.json`), 'utf8')
+  )
+  if (!data[spaceId]) {
+    throw new Error('Invalid space id')
+  }
+  // * Privilege check
+  // 사용자 아이디가 없으면 권한 없음
+
+  data[spaceId].previlige = {
+    edit: false,
+    delete: false
+  }
+  return data[spaceId]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import './App.scss'
 const NotFound = loadable(async () => await import('./pages/NotFound'))
 const Layout = loadable(async () => await import('./components/Layouts/Layout'))
+const SpaceLayout = loadable(async () => await import('./components/Layouts/SpaceLayout'))
 const Home = loadable(async () => await import('./pages/Home'))
 const SharePage = loadable(async () => await import('./pages/Space'))
 const Detail = loadable(async () => await import('./pages/Detail'))
@@ -16,13 +17,10 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/signup" element={<SignUp />} />
         <Route path="/signin" element={<SignIn />} />
-      </Route>
-
-      <Route path="/" element={<Layout />}>
-        {/* todo : edit 페이지 변경 */}
-        <Route path="/space/:spaceId" element={<SharePage />} />
-        {/* todo : /root 페이지 변경, 외부 로그인, 공개 페이지 처리시 이쪽 라우터로 이동 */}
         <Route path="/detail" element={<Detail />} />
+      </Route>
+      <Route path="/" element={<SpaceLayout />}>
+        <Route path="/space/:spaceId" element={<SharePage />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/components/Layouts/SpaceLayout.tsx
+++ b/src/components/Layouts/SpaceLayout.tsx
@@ -1,8 +1,8 @@
 import { Header } from '@/components/Menus/Header'
 import { SideNavBar } from '@/components/Menus/SideNavBar'
-import { SpaceListBar } from '@/components/Menus/SpaceListBar'
+import { useUserStore } from '@/store/user'
 import { Layout as AntdLayout } from 'antd'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import styles from './Layout.module.scss'
 
@@ -10,22 +10,31 @@ const { Content } = AntdLayout
 
 export default function SpaceLayout() {
   const [collapsed, setCollapsed] = useState(false)
+  const { signIn } = useUserStore()
 
   const collapsedChange = (e: boolean) => {
     setCollapsed(e)
   }
+
+  // * 로그인 임시 유지 기능
+  useEffect(() => {
+    // 무조건 1번 유저로 로그인됩니다.
+    signIn({
+      email: 'test1@google.com',
+      password: '1234'
+    })
+  }, [])
 
   return (
     // * HMR을 위해 div로 감싸줍니다.
     <div>
       <div id="portal" />
       <AntdLayout style={{ background: '#fff' }}>
-        <SpaceListBar />
         <AntdLayout>
-          <Header collapsedChange={collapsedChange} collapsed={collapsed} />
           <AntdLayout className={styles.layout}>
             <SideNavBar collapsed={collapsed} />
             <Content>
+              <Header collapsedChange={collapsedChange} collapsed={collapsed} />
               <Outlet />
             </Content>
           </AntdLayout>

--- a/src/components/Menus/SideNavBar.tsx
+++ b/src/components/Menus/SideNavBar.tsx
@@ -27,7 +27,7 @@ const items: MenuProps['items'] = [
     getItem('수신함', '수신함'),
     getItem('보관 문서함', '보관 문서함')
   ]),
-  getItem('관리및문의', '관리및문의', [getItem('어쩌구', '어쩌구'), getItem('저쩌구', '수신함')])
+  getItem('관리및문의', '관리및문의', [getItem('어쩌구', '어쩌구'), getItem('저쩌구', '저쩌구')])
 ]
 
 export function SideNavBar(props: any) {

--- a/src/components/Space/ActionBlockFormBase.module.scss
+++ b/src/components/Space/ActionBlockFormBase.module.scss
@@ -6,10 +6,6 @@
   margin-bottom: 2.5rem;
 }
 
-h2 {
-  padding-left: 1.25rem;
-}
-
 .actionNavigation button {
   width: 4.625rem;
   height: 4.625rem;
@@ -19,12 +15,12 @@ h2 {
   cursor: pointer;
   transition: 0.3s;
   align-items: center;
-  border-radius: .625rem;
+  border-radius: 0.625rem;
   flex-direction: column;
   justify-content: center;
   background-color: white;
-  border: solid .0625rem #eeeeee;
-  box-shadow: 0rem 0rem .5rem .1rem rgba(0, 0, 0, 0.089);
+  border: solid 0.0625rem #eeeeee;
+  box-shadow: 0rem 0rem 0.5rem 0.1rem rgba(0, 0, 0, 0.089);
 }
 
 .icon {
@@ -39,25 +35,24 @@ h2 {
 
 .title {
   display: flex;
-  margin-top: .625rem;
+  margin-top: 0.625rem;
   align-items: center;
   justify-content: center;
 }
 
-
 // active 스타일이 적용되지 않아 !important 사용
 .active {
   font-weight: 500;
-  color: white !important;;
-  border: solid .0625rem #3b51fe !important;
+  color: white !important;
+  border: solid 0.0625rem #3b51fe !important;
   background-color: #4c61ff !important;
-  box-shadow: 0rem 0rem .5rem .25rem rgba(0, 0, 0, 0.173)!important;
+  box-shadow: 0rem 0rem 0.5rem 0.25rem rgba(0, 0, 0, 0.173) !important;
 }
 
 #btnTitle {
   display: flex;
   color: #aeaeae;
-  margin-top: .625rem;
+  margin-top: 0.625rem;
   align-items: center;
   justify-content: center;
 }
@@ -67,5 +62,5 @@ h2 {
   display: flex;
   font-weight: 500;
   justify-content: center;
-  color: rgb(0, 0, 0) !important;;
+  color: rgb(0, 0, 0) !important;
 }

--- a/src/components/Space/ActionBlockFormBase.module.scss
+++ b/src/components/Space/ActionBlockFormBase.module.scss
@@ -21,6 +21,9 @@
   background-color: white;
   border: solid 0.0625rem #eeeeee;
   box-shadow: 0rem 0rem 0.5rem 0.1rem rgba(0, 0, 0, 0.089);
+  &.disable {
+    cursor: default;
+  }
 }
 
 .icon {

--- a/src/components/Space/ActionBlockFormBase.tsx
+++ b/src/components/Space/ActionBlockFormBase.tsx
@@ -56,10 +56,14 @@ export function ActionBlockFormBase({ children }: Props) {
             return (
               <div key={form.type}>
                 <button
-                  className={form.type === blockType ? styles.active : ''}
+                  className={[
+                    form.type === blockType ? styles.active : '',
+                    drawerMode === 'edit' ? styles.disable : ''
+                  ].join(' ')}
                   onClick={() => {
                     setBlockType(form.type)
                   }}
+                  disabled={drawerMode === 'edit'}
                 >
                   <div className={styles.icon}>{form.icon}</div>
                 </button>

--- a/src/components/Space/Profile.tsx
+++ b/src/components/Space/Profile.tsx
@@ -1,16 +1,17 @@
 import { DropDownMenu } from '@/components/Space/DropDownMenu'
+import { type Space } from '@/models/space'
 import { useSpaceModeStore } from '@/store/spaceMode'
-import { useUserStore } from '@/store/user'
 import { Switch } from 'antd'
 import { useMemo } from 'react'
 import { BsThreeDotsVertical } from 'react-icons/bs'
 import { TreeDrawer } from '../Tree/TreeDrawer'
 import styles from './Profile.module.scss'
 
-export function Profile() {
-  const { user } = useUserStore()
+type Props = {
+  space: Space
+}
+export function Profile({ space }: Props) {
   const { mode, setSpaceMode } = useSpaceModeStore()
-
   const items = useMemo(
     () => [
       {
@@ -51,11 +52,11 @@ export function Profile() {
     <div className={styles.container}>
       <div className={styles.profileCover}>
         <div className={styles.profileImageCover}>
-          <img src={user.profileImg} alt={`${user.username} profile`} />
+          <img src={space.profileImage} alt={`${space.title} thumbnail`} />
         </div>
         <div className={styles.profile}>
-          <h2>{user.username}</h2>
-          <p>이 설명란은 아직 추가되지 않음</p>
+          <h2>{space.title}</h2>
+          <p>{space.description}</p>
           <ul className={styles.followCover}>
             <li>
               <span>팔로워</span>
@@ -67,15 +68,18 @@ export function Profile() {
             </li>
           </ul>
           <nav className={styles.navCover}>
+            {/* 이거 하드코딩한 장식용임 이 녀석의 처우는 나중에 생각하자 */}
             <a href="">{'스페이스 홈 바로가기 >'}</a>
           </nav>
         </div>
         <div>
-          <DropDownMenu statefulKeys={['1', '3']} items={items}>
-            <div className={styles.iconCover}>
-              <BsThreeDotsVertical className={styles.icon} />
-            </div>
-          </DropDownMenu>
+          {space.previlige.edit && (
+            <DropDownMenu statefulKeys={['1', '3']} items={items}>
+              <div className={styles.iconCover}>
+                <BsThreeDotsVertical className={styles.icon} />
+              </div>
+            </DropDownMenu>
+          )}
         </div>
       </div>
       {/* 이 부분은 Space Home일 경우 && Admin일 경우만 나와야합니다  */}

--- a/src/components/Space/Profile.tsx
+++ b/src/components/Space/Profile.tsx
@@ -1,5 +1,5 @@
 import { DropDownMenu } from '@/components/Space/DropDownMenu'
-import { type Space } from '@/models/space'
+import { useSpaceStore } from '@/store/space'
 import { useSpaceModeStore } from '@/store/spaceMode'
 import { Switch } from 'antd'
 import { useMemo } from 'react'
@@ -7,11 +7,9 @@ import { BsThreeDotsVertical } from 'react-icons/bs'
 import { TreeDrawer } from '../Tree/TreeDrawer'
 import styles from './Profile.module.scss'
 
-type Props = {
-  space: Space
-}
-export function Profile({ space }: Props) {
+export function Profile() {
   const { mode, setSpaceMode } = useSpaceModeStore()
+  const { space } = useSpaceStore()
   const items = useMemo(
     () => [
       {

--- a/src/components/Space/Profile.tsx
+++ b/src/components/Space/Profile.tsx
@@ -67,7 +67,7 @@ export function Profile() {
           </ul>
           <nav className={styles.navCover}>
             {/* 이거 하드코딩한 장식용임 이 녀석의 처우는 나중에 생각하자 */}
-            <a href="">{'스페이스 홈 바로가기 >'}</a>
+            <a href="/">{'스페이스 홈 바로가기 >'}</a>
           </nav>
         </div>
         <div>

--- a/src/components/Space/SpaceViewer.tsx
+++ b/src/components/Space/SpaceViewer.tsx
@@ -2,7 +2,6 @@ import { ViewerBox } from '@/components/SwitchCase/ViewerBox'
 import { DROPDOWN_TRIGGER_ICON_ID } from '@/constants'
 import type { BlockType, Space } from '@/models/space'
 import { useActiveBlock } from '@/store/activeBlock'
-import { useSpaceStore } from '@/store/space'
 import { useSpaceModeStore } from '@/store/spaceMode'
 import { useEffect, useState } from 'react'
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout'
@@ -12,10 +11,13 @@ import styles from './SpaceViewer.module.scss'
 
 const ResponsiveGridLayout = WidthProvider(Responsive)
 
-export function SpaceViewer() {
+type Props = {
+  space: Space
+}
+export function SpaceViewer({ space }: Props) {
   const [rowHeight, setRowHeight] = useState(100)
   const { mode } = useSpaceModeStore()
-  const { space } = useSpaceStore()
+
   const [grid, setGridLayout] = useState({
     breakpoints: 'lg',
     layouts: { lg: getBlockLayout(space.blocks, mode) } // , md: layout, sm: layout, xs: layout, xxs: layout

--- a/src/components/Space/SpaceViewer.tsx
+++ b/src/components/Space/SpaceViewer.tsx
@@ -2,6 +2,7 @@ import { ViewerBox } from '@/components/SwitchCase/ViewerBox'
 import { DROPDOWN_TRIGGER_ICON_ID } from '@/constants'
 import type { BlockType, Space } from '@/models/space'
 import { useActiveBlock } from '@/store/activeBlock'
+import { useSpaceStore } from '@/store/space'
 import { useSpaceModeStore } from '@/store/spaceMode'
 import { useEffect, useState } from 'react'
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout'
@@ -11,11 +12,9 @@ import styles from './SpaceViewer.module.scss'
 
 const ResponsiveGridLayout = WidthProvider(Responsive)
 
-type Props = {
-  space: Space
-}
-export function SpaceViewer({ space }: Props) {
+export function SpaceViewer() {
   const [rowHeight, setRowHeight] = useState(100)
+  const { space } = useSpaceStore()
   const { mode } = useSpaceModeStore()
 
   const [grid, setGridLayout] = useState({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,6 +2,7 @@ export const API_DELAY = 1000
 export const ABORT_DELAY = 10000
 export const POST_API_KEY = 'POST_API_KEY'
 export const SEO = 'SEO'
+export const SPACE = 'SPACE'
 export const HOME_RPOMISE_API_KEY = 'HOME_RPOMISE_API_KEY'
 
 export const ACCESS_TOKEN = 'token'

--- a/src/hooks/serverSideProps.ts
+++ b/src/hooks/serverSideProps.ts
@@ -9,7 +9,6 @@ export default function useServerSideProps(key: string) {
     return JSON.parse((ctx[key] as string) || '{}')
   }
   const serverSideData = document.getElementById('__SERVER_DATA__')?.textContent ?? '{}'
-
   const data = JSON.parse(htmlEntitiesDecoder(serverSideData))
   return JSON.parse(data[key]) || ''
 }

--- a/src/models/space.ts
+++ b/src/models/space.ts
@@ -4,6 +4,8 @@
 // }
 
 export interface Space {
+  spaceId: string
+  profileImage: string
   title: string
   description: string
   previlige: {

--- a/src/pages/Home/Home.module.scss
+++ b/src/pages/Home/Home.module.scss
@@ -1,5 +1,5 @@
 @import '/src/variables.scss';
 
 .container {
-  background-color: $jober-blue;
+  background-color: $base-white;
 }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,7 +5,12 @@ export default function Home() {
   return (
     <div className={styles.container}>
       <h1>HOME PAGE</h1>
-      <Link to="/space/user1">user1의 스페이스로 이동하기</Link>
+      <div>
+        <Link to="/space/space1">user1의 스페이스로 이동하기</Link>
+      </div>
+      <div>
+        <Link to="/space/space2">user2의 스페이스로 이동하기</Link>
+      </div>
     </div>
   )
 }

--- a/src/pages/Space/index.tsx
+++ b/src/pages/Space/index.tsx
@@ -5,7 +5,6 @@ import { SEO, SPACE } from '@/constants'
 import useServerSideProps from '@/hooks/serverSideProps'
 import { type Space } from '@/models/space'
 import { useSpaceStore } from '@/store/space'
-import { useUserStore } from '@/store/user'
 import { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
 import { useParams } from 'react-router-dom'
@@ -26,7 +25,6 @@ export default function SharePage() {
   const pageSource: PageSource = useServerSideProps(SEO)
   const SSRSpace: Space = useServerSideProps(SPACE)
   const { space, loadSpace, setSpace, isLoaded, isFetching } = useSpaceStore()
-  const { isSignedIn } = useUserStore()
   const { spaceId } = useParams<Params>()
 
   useEffect(() => {
@@ -53,7 +51,7 @@ export default function SharePage() {
       }
     }
     setSpace(nextSpace)
-  }, [spaceId, isSignedIn])
+  }, [spaceId])
 
   useEffect(() => {
     // * fetching이 완료되면 페이지 권한을 체크 후 업데트합니다. (임시)
@@ -65,6 +63,8 @@ export default function SharePage() {
           delete: space.spaceId === 'space1'
         }
       }
+      // console.log('nextSpace :', nextSpace)
+
       setSpace(nextSpace)
     }
   }, [isFetching])
@@ -75,11 +75,11 @@ export default function SharePage() {
         {/* todo : default pageSource + SSR일 경우 두 가지로 분기해야함 */}
         <title>{pageSource.title['/']}</title>
       </Helmet>
-      {isLoaded && <Profile space={space} />}
+      {isLoaded && <Profile />}
       <aside>{<Drawer />}</aside>
       <div className={styles.viewer}>
         <div className={styles.spaceViewer}>
-          <section>{isLoaded && <SpaceViewer space={space} />}</section>
+          <section>{isLoaded && <SpaceViewer />}</section>
         </div>
       </div>
     </>

--- a/src/pages/Space/index.tsx
+++ b/src/pages/Space/index.tsx
@@ -1,8 +1,9 @@
 import { Drawer } from '@/components/Space/Drawer'
 import { Profile } from '@/components/Space/Profile'
 import { SpaceViewer } from '@/components/Space/SpaceViewer'
-import { SEO } from '@/constants'
+import { SEO, SPACE } from '@/constants'
 import useServerSideProps from '@/hooks/serverSideProps'
+import { type Space } from '@/models/space'
 import { useSpaceStore } from '@/store/space'
 import { useUserStore } from '@/store/user'
 import { useEffect } from 'react'
@@ -14,6 +15,7 @@ import styles from './Space.module.scss'
 // const TreeTest = loadable(async () => await import('../../components/TreeTest'), { ssr: false })
 interface PageSource {
   title: Record<string, string>
+  description: Record<string, string>
 }
 
 type Params = {
@@ -22,39 +24,62 @@ type Params = {
 
 export default function SharePage() {
   const pageSource: PageSource = useServerSideProps(SEO)
-  const { user, isSignedIn } = useUserStore()
-  const { loadSpace, isLoaded } = useSpaceStore()
-
+  const SSRSpace: Space = useServerSideProps(SPACE)
+  const { space, loadSpace, setSpace, isLoaded, isFetching } = useSpaceStore()
+  const { isSignedIn } = useUserStore()
   const { spaceId } = useParams<Params>()
-  // const { mode, setSpaceMode } = useSpaceModeStore()
-  // const { space } = useSpaceStore()
 
   useEffect(() => {
-    if (!user.userId) return
-    loadSpace(spaceId ?? '')
-  }, [isSignedIn])
+    // * CSR일 경우 space를 로드합니다.
+    if (!SSRSpace?.spaceId) {
+      loadSpace(spaceId ?? '')
+      return
+    }
+
+    // * CSR일 경우 스페이스가 변경되었다면 space를 다시 로드합니다.
+    if (SSRSpace?.spaceId !== spaceId) {
+      loadSpace(spaceId ?? '')
+      return
+    }
+
+    // * SSR일 경우 SSRSpace를 사용합니다.
+    const nextSpace: Space = {
+      ...SSRSpace,
+      previlige: {
+        edit: SSRSpace.spaceId === 'space1',
+        delete: SSRSpace.spaceId === 'space1'
+      }
+    }
+    setSpace(nextSpace)
+
+    // * 페이지 권한을 확인합니다. (임시)
+  }, [spaceId, isSignedIn])
+
+  useEffect(() => {
+    if (!isFetching) {
+      const nextSpace: Space = {
+        ...space,
+        previlige: {
+          edit: space.spaceId === 'space1',
+          delete: space.spaceId === 'space1'
+        }
+      }
+      setSpace(nextSpace)
+    }
+  }, [isFetching])
 
   return (
     <>
       <Helmet>
+        {/* todo : default pageSource + SSR일 경우 두 가지로 분기해야함 */}
         <title>{pageSource.title['/']}</title>
       </Helmet>
-      <Profile />
-      {/* {space.previlige.edit && (
-        <Button
-          onClick={() => {
-            setSpaceMode(mode === 'view' ? 'edit' : 'view')
-          }}
-        >
-          {mode === 'view' ? '공유 화면 보기' : '수정 하기'}
-        </Button>
-      )} */}
-      <aside>{isLoaded && isSignedIn && <Drawer />}</aside>
+      {isLoaded && <Profile space={space} />}
+      <aside>{<Drawer />}</aside>
       <div className={styles.viewer}>
         <div className={styles.spaceViewer}>
-          <section>{isLoaded && isSignedIn && <SpaceViewer />}</section>
+          <section>{isLoaded && <SpaceViewer space={space} />}</section>
         </div>
-        {/* <TreeTest /> */}
       </div>
     </>
   )

--- a/src/pages/Space/index.tsx
+++ b/src/pages/Space/index.tsx
@@ -30,19 +30,21 @@ export default function SharePage() {
   const { spaceId } = useParams<Params>()
 
   useEffect(() => {
-    // * CSR일 경우 space를 로드합니다.
+    // * react 내부적으로 주소를 이동할 경우 space를 다시 로드합니다.
     if (!SSRSpace?.spaceId) {
       loadSpace(spaceId ?? '')
       return
     }
 
-    // * CSR일 경우 스페이스가 변경되었다면 space를 다시 로드합니다.
+    // * react 내부적으로 주소를 이동할 경우
+    // * SSR로 로드한 spaceId와 이동할 space가 다르다면 space를 다시 로드합니다.
     if (SSRSpace?.spaceId !== spaceId) {
       loadSpace(spaceId ?? '')
       return
     }
 
     // * SSR일 경우 SSRSpace를 사용합니다.
+    // * 권한은 임시로 업데이트하는 척 합니다. (임시)
     const nextSpace: Space = {
       ...SSRSpace,
       previlige: {
@@ -51,11 +53,10 @@ export default function SharePage() {
       }
     }
     setSpace(nextSpace)
-
-    // * 페이지 권한을 확인합니다. (임시)
   }, [spaceId, isSignedIn])
 
   useEffect(() => {
+    // * fetching이 완료되면 페이지 권한을 체크 후 업데트합니다. (임시)
     if (!isFetching) {
       const nextSpace: Space = {
         ...space,

--- a/src/store/activeBlock.ts
+++ b/src/store/activeBlock.ts
@@ -2,22 +2,15 @@ import { create } from 'zustand'
 
 interface SpaceActiveState {
   activeBlockId: string
-  activeBlockPositionTop: number
-  activeBlockPositionRight: number
+
   setActiveBlockId: (id: string) => void
-  setActiveBlockPosition: (top: number, right: number) => void
 }
 
 export const useActiveBlock = create<SpaceActiveState>((set) => {
   return {
     activeBlockId: '',
-    activeBlockPositionTop: 0,
-    activeBlockPositionRight: 0,
     setActiveBlockId: (id: string) => {
       set((state) => ({ ...state, activeBlockId: id }))
-    },
-    setActiveBlockPosition: (top: number, right: number) => {
-      set((state) => ({ ...state, activeBlockPositionTop: top, activeBlockPositionRight: right }))
     }
   }
 })

--- a/src/store/space.ts
+++ b/src/store/space.ts
@@ -2,22 +2,30 @@ import { getSpaceAPI } from '@/api/space'
 import { type Space } from '@/models/space'
 import { create } from 'zustand'
 
+interface Privilege {
+  edit: boolean
+  delete: boolean
+}
 interface SpaceState {
   space: Space // ? Partial<Space> | Space  할까요? Space 할까요?
   isFetching: boolean
   isLoaded: boolean
   isFalture: boolean
   loadSpace: (id: string) => Promise<boolean>
+  // loadSpacePrivligeByUserId: (userId: string) => Promise<Privilege>
   addBlock: (section_id: string, options: object) => Promise<boolean>
   removeBlock: (section_id: string, block_id: string) => Promise<boolean>
+  setPrivilege: (previlige: Privilege) => void
   removeBlockById: (blockId: string) => void
+  setSpace: (space: Space) => void
 }
 
 export const useSpaceStore = create<SpaceState>((set) => {
   return {
     // ? 이거 속성 다 뺄 수 없나..? Partial<Space> | Space 이렇게 되면 좋게싸..
     space: {
-      space_id: '',
+      spaceId: '',
+      profileImage: '/profile_3.png', // * default image 넣어야함
       layout: {
         styles: {}
       },
@@ -29,18 +37,26 @@ export const useSpaceStore = create<SpaceState>((set) => {
       },
       blocks: []
     },
-    isFetching: false,
+    isFetching: true,
     isLoaded: false,
     isFalture: false,
     loadSpace: async (id: string) => {
-      set((state) => ({ ...state, isFetching: true, isLoaded: false, isFalture: false }))
+      set(() => ({ isFetching: true, isLoaded: false, isFalture: false }))
+
       const { data } = await getSpaceAPI(id)
+
       if (data) {
-        set((state) => ({ ...state, space: data, isFetching: false, isLoaded: true, isFalture: false }))
+        set(() => ({ space: data, isFetching: false, isLoaded: true, isFalture: false }))
         return true
       }
-      set((state) => ({ ...state, isFetching: false, isLoaded: false, isFalture: true }))
+      set(() => ({ isFetching: false, isLoaded: false, isFalture: true }))
       return false
+    },
+    setSpace: (space: Space) => {
+      set(() => ({ space, isLoaded: true, isFalture: false }))
+    },
+    setPrivilege: (privilege: Privilege) => {
+      set((state) => ({ ...state, space: { ...state.space, previlige: privilege } }))
     },
     removeBlockById: async (blockId: string) => {
       set((state) => {
@@ -54,6 +70,9 @@ export const useSpaceStore = create<SpaceState>((set) => {
         return { ...state }
       })
     },
+    // loadSpacePrivligeById: async (userId: string, spaceId: string) => {
+    //   return { edit: true, delete: true }
+    // },
     // ! 미구현 ㅎㅅㅎ
     addBlock: async (sectionId: string, options: object) => {
       return true


### PR DESCRIPTION
# 요약

SSR 및 hydration 이후 react 내부 페이지 이동 관련 작업을 추가했습니다.

# 상세 설명

src/pages/Space.tsx를 참고해주세요.

SSR, react 내부 페이지 이동시 space 정보를 호출하는 로직을 아래와 같이 수정했습니다.

<img width="469" alt="스크린샷 2023-09-20 오후 7 43 42" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/73880776/fb0a82be-68a6-4379-8a2e-cd72ef2bf11c">

mock API는 페이지 이동시 로그인이 풀리기 때문에 

**테스트를 위해서 강제로 로그인되게 했습니다.**

<img width="750" alt="스크린샷 2023-09-20 오후 7 45 34" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/73880776/86a309df-c92e-492f-a0fd-b9a88c0dd261">

그래서 'test1@googl.com'의 최상위 스페이스인 'space/space1'에 접속할 경우 수정 권한이 있지만

수정 권한이 없는 'space/space2'에 접속할 경우 수정할 수 없습니다.

<img width="793" alt="스크린샷 2023-09-20 오후 7 48 48" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/73880776/36de5239-3342-442d-b87c-1e9c64172279">


<img width="799" alt="스크린샷 2023-09-20 오후 7 49 02" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/73880776/365241d6-36f4-4c46-8048-beaeeca1145d">

**space/space1은 수정 권한이 있음**

<img width="799" alt="스크린샷 2023-09-20 오후 7 49 11" src="https://github.com/JoberChipFrappuccino/joberchip-fe/assets/73880776/4ed2df17-0828-4ce2-95b4-13460556eb51">

**space/space2는 수정 권한이 없음**







