### PR TITLE
맵 블록 수정시 바로 적용, 상세주소 초기화, 상세주소에 x버튼 생성 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ## 👤 TEAM JOBERCHIP
 
 **FRONT-END**
-|[정태욱](https://github.com/peacepiece7)(👑)|[김다슬](https://github.com/7581058-UQ)|[박철민](https://github.com/DICEPT)|[백지욱](https://github.com/atsunsetree)|[주하림](https://github.com/nyeJiiii)|
+|[정태욱](https://github.com/peacepiece7)(👑)|[김다슬](https://github.com/7581058-UQ)|[박철민](https://github.com/DICEPT)|[백지욱](https://github.com/beakjiuk)|[주하림](https://github.com/nyeJiiii)|
 |:---:|:---:|:---:|:---:|:---:|
 |<a href="https://github.com/gdtknight"><img src="https://avatars.githubusercontent.com/u/73880776?v=4" width=150px alt="정태욱">|<a href="https://github.com/Horaiz-UQ"><img src="https://avatars.githubusercontent.com/u/100559990?v=4" width=150px alt="김다슬">|<a href="https://github.com/DICEPT"><img src="https://avatars.githubusercontent.com/u/106785596?v=4" width=150px alt="박철민">|<a href="https://github.com/beakjiuk"><img src="https://avatars.githubusercontent.com/u/83908991?v=4" width=150px alt="백지욱">|<a href="https://github.com/wngkfla01"><img src="https://avatars.githubusercontent.com/u/64509945?v=4" width=150px alt="주하림">|
 

--- a/src/components/Blocks/GoogleMapBlock.tsx
+++ b/src/components/Blocks/GoogleMapBlock.tsx
@@ -4,33 +4,27 @@ import { useEffect, useState } from 'react'
 import { SkeletonTheme } from 'react-loading-skeleton'
 import { type BlockBaseWithBlockProps } from '../SwitchCase/ViewerBox'
 import styles from './GoogleMapBlock.module.scss'
-interface Props {
-  latitude: number
-  longitude: number
-  lat?: BlockBaseWithBlockProps<TMap>['block']['latitude']
-  lng?: BlockBaseWithBlockProps<TMap>['block']['longitude']
-}
 
 export function GoogleMapBlock({ block, mode }: BlockBaseWithBlockProps<TMap>) {
-  const location: Props = block?.src ? JSON.parse(block.src.replace(/\\/g, '')) : {}
+  const location = block?.src ? JSON.parse(block.src) : {}
   const { isLoaded } = useJsApiLoader({
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAPS_API ?? '',
     libraries: ['places']
   })
-  const [isLoading, setIsLoading] = useState(true) // 로딩 상태 추가
+  const [isLoading, setIsLoading] = useState(true)
+
   useEffect(() => {
     if (!isLoaded) {
-      setIsLoading(true) // 로딩 중
+      setIsLoading(true)
       return
     }
-    setIsLoading(false) // 로딩 완료
-    // 여기에서 다른 동작을 수행할 수 있습니다.
+    setIsLoading(false)
   }, [isLoaded])
 
-  const [center] = useState({
+  const center = {
     lat: location?.latitude ?? block?.latitude ?? 37.5642135,
     lng: location?.longitude ?? block?.longitude ?? 127.0016985
-  })
+  }
 
   return (
     <div className={styles.container}>

--- a/src/components/Forms/GoogleMapBlockForm.tsx
+++ b/src/components/Forms/GoogleMapBlockForm.tsx
@@ -8,6 +8,7 @@ import { Autocomplete, GoogleMap, Marker, useJsApiLoader } from '@react-google-m
 import { Input } from 'antd'
 import { type SearchProps } from 'antd/es/input/Search'
 import React, { useEffect, useState, type ChangeEvent, type FormEvent } from 'react'
+import { TiDeleteOutline } from 'react-icons/ti'
 import { SkeletonTheme } from 'react-loading-skeleton'
 import { type BlockBaseWithBlockFormProps } from '../SwitchCase/DrawerEditForm'
 import FormButton from '../Ui/Button'
@@ -108,13 +109,26 @@ export function GoogleMapBlockForm({ block }: BlockBaseWithBlockFormProps<TMap>)
         toast('지도가 추가되었습니다.', 'success', { autoClose: 500 })
         setOpenDrawer(false)
       } else if (drawerMode === 'edit') {
-        await editGoogleMapBlockAPI(pageId, blockId, {
+        const { data: responseData } = await editGoogleMapBlockAPI(pageId, blockId, {
           latitude: center.lat,
           longitude: center.lng,
           address
         })
+        const existingBlockIndex = sharePage.children.findIndex((block) => block.objectId === responseData.objectId)
+        const updatedChildren = [...sharePage.children]
+        if (existingBlockIndex !== -1) {
+          updatedChildren[existingBlockIndex] = responseData
+        } else {
+          updatedChildren.push(responseData)
+        }
+        const updatedSharePage = {
+          ...sharePage,
+          children: updatedChildren
+        }
+        setSharePage(updatedSharePage)
         toast('지도가 수정되었습니다.', 'success', { autoClose: 500 })
         setOpenDrawer(false)
+        setAddress('')
       }
     } catch (error) {
       console.error(error)
@@ -181,6 +195,11 @@ export function GoogleMapBlockForm({ block }: BlockBaseWithBlockFormProps<TMap>)
           <h3>상세주소</h3>
           <div className={styles.inputbox}>
             <input type="text" value={address} onChange={onChangeAddress} placeholder="주소를 입력해주세요" />
+            {address && (
+              <button type="button" className={styles.delTitle} onClick={() => setAddress('')}>
+                <TiDeleteOutline />
+              </button>
+            )}
           </div>
         </div>
         <FormButton title={drawerMode === 'create' ? '지도 추가하기' : '지도 수정하기'} event={isButtonDisabled} />


### PR DESCRIPTION
맵 블록 수정시 새로고침 없이 바로 적용, 상세주소 초기화, 상세주소에 x버튼 생성
Autocomplete 의 Search 제목은 초기화 하지못함

# 요약

# 상세 설명
맵 블록 수정시 새로고침 없이 바로 적용 이 코드는 JSON.parse(responseData.src.replace(/\\/g, ''))를 사용해서 적용되지 않는 오류입니다. 블록과 폼에 다 제거했습니다.
# 참고 
